### PR TITLE
Prettier syntax

### DIFF
--- a/SpottrServer/test.sh
+++ b/SpottrServer/test.sh
@@ -2,80 +2,88 @@
 
 # This script tries every endpoint of the API and reports whether the operation succeeded or failed.
 # Currently failure status is reported by the API returning a failure message. This should probably
-# be expanded upon
+# be expanded upon.
 
-# colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NOCOLOR='\033[0m'
+test_spottr_api() (
+    # Program Arguments (With default values)
+    HOSTNAME=${1:-localhost}
+    PORT=${2:-8000}
 
-HOSTNAME="localhost"
-PORT=8000
+    # Colors
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    NOCOLOR='\033[0m'
 
-# GET TESTS
-get_tests=(
-    spottrsites
-    spottrsites/1
-    spottrsites/1/parkinglots
-    parkinglots
-    parkinglots/1
-    parkinglots/1/spottrnodes
-    parkinglots/1/masternodes
-    parkinglots/1/slavenodes
-    parkinglots/1/parkingspots
-    spottrnodes
-    spottrnodes/1
-    slavenodes
-    slavenodes/1
-    masternodes
-    masternodes/1
-    masternodes/1/slavenodes
-    parkingspots
-)
+    PASS="${GREEN}[PASSED]${NOCOLOR}"
+    FAIL="${RED}[FAILED]${NOCOLOR}"
+    API_URL="http://${HOSTNAME}:${PORT}/api"
+    ERRVAL=0
 
-# these are failing due to some error where the entire value isnt being sent. this gives a json formatting
-# error
-declare -A post_tests
-post_tests=(
-    ["spottrsites"]="{\"sitename\":\"testsite\",\"address\":\"1 testsite drive\"}"
-    ["parkinglots"]='{"lotname":"testlot", "spottrsite":"0", "perimeter":"[]"}'
-    ["masternodes"]='["nodename": "testmasternode", "parkinglot": "0", "location":"testlocation", "numsensors": "3", "hostname": "testhost"}'
-    ["slavenodes"]='["nodename": "testmasternode", "parkinglot": "0", "location":"testlocation", "numsensors": "3", "masternode": "0"}'
-    ["parkingspots"]='["spotname": "testspot", "spottrnode": 0, "sensornum": 3, "occupied": 0, "longitude": 76.6, "latitude": 50.1]'
-)
+    # GET TESTS
+    get_tests=(
+        spottrsites
+        spottrsites/1
+        spottrsites/1/parkinglots
+        parkinglots
+        parkinglots/1
+        parkinglots/1/spottrnodes
+        parkinglots/1/masternodes
+        parkinglots/1/slavenodes
+        parkinglots/1/parkingspots
+        spottrnodes
+        spottrnodes/1
+        slavenodes
+        slavenodes/1
+        masternodes
+        masternodes/1
+        masternodes/1/slavenodes
+        parkingspots
+    )
 
-# test the error case
-resp=$(curl -s -X "GET" http://${HOSTNAME}:${PORT}/api/error)
-    if [[ $resp != *"error"* ]]; then
-        printf "${RED}[FAILED]${NOCOLOR}"
-    else
-        printf "${GREEN}[PASSED]${NOCOLOR}"
-    fi
+    # These are failing due to some error where the entire value isnt being sent
+    # This gives a json formatting error
+    post_tests=(
+        ["spottrsites"]="{\"sitename\":\"testsite\",\"address\":\"1 testsite drive\"}"
+        ["parkinglots"]='{"lotname":"testlot", "spottrsite":"0", "perimeter":"[]"}'
+        ["masternodes"]='["nodename": "testmasternode", "parkinglot": "0", "location":"testlocation", "numsensors": "3", "hostname": "testhost"}'
+        ["slavenodes"]='["nodename": "testmasternode", "parkinglot": "0", "location":"testlocation", "numsensors": "3", "masternode": "0"}'
+        ["parkingspots"]='["spotname": "testspot", "spottrnode": 0, "sensornum": 3, "occupied": 0, "longitude": 76.6, "latitude": 50.1]'
+    )
 
+    #-----------
+    #-- USAGE --
+    #-----------
+    usage() {
+        printf "
+Spottr API tester V2.0
+usage: $0 [hostname] [port]
+
+"
+    }
+
+    #----------
+    #-- MAIN --
+    #----------
+    # Test the error case
+    resp=$(curl -s -X "GET" ${API_URL}/error 2>/dev/null)
+    [[ $resp != *"error"* ]] && printf "${FAIL}" || printf "${PASS}"
     printf " Test [GET] error case\n"
 
-# test the GET cases. these should all pass
-for i in "${get_tests[@]}"; do
-    resp=$(curl -s -X "GET" http://${HOSTNAME}:${PORT}/api/$i)
+    # Test the GET cases. these should all pass
+    for test in "${get_tests[@]}"; do
+        resp=$(curl -s --request GET ${API_URL}/$test 2>/dev/null)
+        [[ $resp == *"error"* ]] && printf "${FAIL}" || printf "${PASS}"
+        printf " Test [GET] $test\n"
+    done
 
-    if [[ $resp == *"error"* ]]; then
-        printf "${RED}[FAILED]${NOCOLOR}"
-    else
-        printf "${GREEN}[PASSED]${NOCOLOR}"
-    fi
+    # Test the POST cases. these should all pass
+    for i in "${!post_tests[@]}"; do
+        resp=$(curl -s --header "Content-Type: application/json" --request POST --data ${post_tests[$i]} ${API_URL}/$i 2>/dev/null)
+        [[ $resp == *"Error"* ]] && printf "${FAIL}" || printf "${PASS}"
+        printf " Test [POST] ${i}\n"
+    done
 
-    printf " Test [GET] $i\n"
-done
+    return $ERRVAL
+)
 
-# test the POST cases. these should all pass
-for i in "${!post_tests[@]}"; do
-    resp=$(curl -s --header "Content-Type: application/json" --request POST --data ${post_tests[$i]} http://${HOSTNAME}:${PORT}/api/$i)
-
-    if [[ $resp == *"Error"* ]]; then
-        printf "${RED}[FAILED]${NOCOLOR}"
-    else
-        printf "${GREEN}[PASSED]${NOCOLOR}"
-    fi
-
-    printf " Test [POST] ${i}\n"
-done
+test_spottr_api $@


### PR DESCRIPTION
- Threw whole thing in function to allow for ```return```
- Script takes optional _hostname_ and _port_ arguments with preloaded default values
- Clunky if changed to bash _ternary_ 
- Usage function implemented but not used